### PR TITLE
Resolved issues with consuming new and old log streams.

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,11 +96,12 @@ Source.prototype._pollLogStreams = function(nextToken) {
 
 				if(!(name in self._streams)) {
 					self._streams[name] = ingestion;
+					if(ingestion >= self.StartTime) {
+						self._queuedStreams.push(name);	
+					}
 				} else if(self._streams[name] < ingestion) {
 					self._streams[name] = ingestion;
-					//if(ingestion >= self.StartTime) { // TODO Fix this to work with local time
-						self._queuedStreams.push(name);	
-					//}
+					self._queuedStreams.push(name);	
 				}
 			}
 		}


### PR DESCRIPTION
- New log streams created after the process is started are now consumed as expected.
- Setting a StartTime now works as expected.
